### PR TITLE
fix: Allow overriding ANTProfile::ProcessMessage()

### DIFF
--- a/src/ANTProfile.cpp
+++ b/src/ANTProfile.cpp
@@ -459,6 +459,14 @@ uint32_t ANTProfile::Setup(uint8_t channel)
         }
     }
 
+    if (_BeforeOpenChannel) {
+      err_code = _BeforeOpenChannel(m_channel_number);
+      if (err_code != NRF_SUCCESS)
+      {
+        return err_code;
+      }
+    }
+
     err_code = sd_ant_channel_open(m_channel_number);
     if (err_code != NRF_SUCCESS)
     {

--- a/src/ANTProfile.h
+++ b/src/ANTProfile.h
@@ -100,7 +100,7 @@ public:
    const char* getName(void) {return name;}
    uint8_t getChannelNumber(void) { return m_channel_number;}
 
-   void ProcessMessage(ant_evt_t* evt);
+   virtual void ProcessMessage(ant_evt_t* evt);
    void setUnhandledEventListener(void (*fp)(ant_evt_t* evt)) { _AntUnhandledEventLister = fp; };
    void setAllEventListener(void (*fp)(ant_evt_t* evt)) { _AntAllEventLister = fp; };
    //void setCustomDataPtr(void* ptr) { m_customDataPtr = ptr;}

--- a/src/ANTProfile.h
+++ b/src/ANTProfile.h
@@ -92,7 +92,7 @@ public:
 
    ANTProfile(ANTTransmissionMode mode);
 
-   //profile operartions 
+   //profile operations
    uint32_t Setup(uint8_t channel);
     
    //Profile name 
@@ -103,6 +103,7 @@ public:
    virtual void ProcessMessage(ant_evt_t* evt);
    void setUnhandledEventListener(void (*fp)(ant_evt_t* evt)) { _AntUnhandledEventLister = fp; };
    void setAllEventListener(void (*fp)(ant_evt_t* evt)) { _AntAllEventLister = fp; };
+   void setBeforeOpenChannel(uint32_t (*fp)(uint8_t channel)) { _BeforeOpenChannel = fp; };
    //void setCustomDataPtr(void* ptr) { m_customDataPtr = ptr;}
    //void* getCustomDataPtr(void) {return m_customDataPtr;} 
    bool newRxData = false;
@@ -114,7 +115,8 @@ protected:
    virtual void EncodeMessage() = 0;
    uint32_t SendMessage();
    void (*_AntUnhandledEventLister)(ant_evt_t* evt) = NULL; 
-   void (*_AntAllEventLister)(ant_evt_t* evt) = NULL; 
+   void (*_AntAllEventLister)(ant_evt_t* evt) = NULL;
+   uint32_t (*_BeforeOpenChannel)(uint8_t chan) = NULL;
    const char *  name = "";
 
    uint8_t m_channel_number; ///< Channel number assigned to the profile.

--- a/src/profiles/BicycleSpeedCadence.h
+++ b/src/profiles/BicycleSpeedCadence.h
@@ -318,8 +318,6 @@ class BicycleSpeedCadence : public ANTProfile
 public:
    BicycleSpeedCadence(BSCDeviceType d_t, ANTTransmissionMode mode);
 
-   void ProcessMessage(ant_evt_t*);
-
    // void SetSpeed(float val);
    // float GetSpeed() { return m_speed; };
 

--- a/src/profiles/Environment.hh
+++ b/src/profiles/Environment.hh
@@ -253,7 +253,7 @@ public:
     EnvironmentSensor(ANTTransmissionMode mode);
     //~EnvironmentRx();
     //bool Setup();
-    //void ProcessMessage(ant_evt_t*);
+    void ProcessMessage(ant_evt_t*) override;
     void SetOnTemperatureData(void (*fp)(int16_t)) {_OnTemperatureData_cb = fp;}
 };
 

--- a/src/profiles/HeartRateMonitor.h
+++ b/src/profiles/HeartRateMonitor.h
@@ -222,8 +222,6 @@ class HeartRateMonitor : public ANTProfile
 public:
    HeartRateMonitor(ANTTransmissionMode mode);
 
-   void ProcessMessage(ant_evt_t*);
-
    void SetOnComputedHeartRate(void (*fp)(int)) { _OnComputedHeartRate_cb = fp;}
 
 


### PR DESCRIPTION
Otherwise it's not possible to cleanly send acknowledgement messages (with no regular data frames sent) as it will happily keep encoding/sending the last contents of the buffer on every tick.